### PR TITLE
Fix QCursor and QTextDocument missing import statements

### DIFF
--- a/lessons/lessonselector.py
+++ b/lessons/lessonselector.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import QUrl
-from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon, QTextDocument
 from qgis.PyQt.QtWidgets import QTreeWidgetItem, QDialogButtonBox
 
 from lessons import lessons

--- a/lessons/lessonwidget.py
+++ b/lessons/lessonwidget.py
@@ -5,7 +5,7 @@ import os
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt, QCoreApplication, QUrl, pyqtSignal
-from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon, QTextDocument
 from qgis.PyQt.QtWidgets import QListWidgetItem, QMessageBox, QListWidget
 from qgis.utils import iface
 

--- a/lessons/utils.py
+++ b/lessons/utils.py
@@ -7,6 +7,7 @@ import time
 import shutil
 
 from qgis.PyQt.QtCore import QDir, QSettings, QThread, pyqtSignal, Qt
+from qgis.PyQt.QtGui import QCursor
 from qgis.PyQt.QtWidgets import QMenu, QApplication
 
 from qgis.core import QgsMapLayerRegistry, QgsVectorLayer, QgsRasterLayer


### PR DESCRIPTION
When I was trying locally your plugin, I had various errors returned due to missing import

Line https://github.com/webgeodatavore/qgis-lessons-plugin/blob/fix-missing-imports/lessons/utils.py#L10 fixes https://github.com/webgeodatavore/qgis-lessons-plugin/blob/fix-missing-imports/lessons/utils.py#L152

Line https://github.com/webgeodatavore/qgis-lessons-plugin/blob/fix-missing-imports/lessons/lessonselector.py#L8 fixes https://github.com/webgeodatavore/qgis-lessons-plugin/blob/fix-missing-imports/lessons/lessonselector.py#L66

Line https://github.com/webgeodatavore/qgis-lessons-plugin/blob/fix-missing-imports/lessons/lessonwidget.py#L8 fixes https://github.com/webgeodatavore/qgis-lessons-plugin/blob/fix-missing-imports/lessons/lessonwidget.py#L96
